### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/libre-streaming.py
+++ b/libre-streaming.py
@@ -121,7 +121,7 @@ class LibreStreaming:
 def main(filename='libre-streaming.conf'):
     config = configparser.ConfigParser()
     if not config.read(filename):
-        print("Unable to read %s" % filename)
+        print("Unable to read {0!s}".format(filename))
         exit(1)
     libreStreaming = LibreStreaming(config)
     libreStreaming.play()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:ViGLug:libre-streaming?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:ViGLug:libre-streaming?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
